### PR TITLE
Adding instructions for avx2 keccak library (#4)

### DIFF
--- a/_docs/node/QRLnode.md
+++ b/_docs/node/QRLnode.md
@@ -21,6 +21,7 @@ You can run QRL on most operating systems, though Ubuntu 16.04 is recommended.
 {: .info}
 
 - Support for AES-NI
+- Support for avx2 (Used by keccak library for hashing functions)
 - HDD with enough storage for the blockchain as it grows
 - Reliable network connection 
 - Python3.6


### PR DESCRIPTION
Per issue [#1614](https://github.com/theQRL/QRL/issues/1614) user ran into the requirement for hardware that supports the avx2 keccak library. Thanks @useribs for reporting the issue.