### PR TITLE
Update menu font

### DIFF
--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -275,8 +275,8 @@
 
 	}
 	nav a {
-		font-family: 'Quicksand';
-		font-weight: 500;
+		font-family: $heading_font;
+		font-weight: 300;
 		font-size:13px;
 		text-transform: uppercase;
 		padding:5px 20px;


### PR DESCRIPTION
The SASS for the header menu still contains Quicksand, which we have been depreciating.  This PR removes the hard-coded Quicksand font and replaces it with the header font variable.