### PR TITLE
Fixes to Node document and typo in Ledger Document

### DIFF
--- a/_docs/node/QRLnode.md
+++ b/_docs/node/QRLnode.md
@@ -39,6 +39,10 @@ sudo apt update && sudo apt upgrade -y
 # Install Required dependencies
 {{ layout.v.qrlCommands.qrlRequirementsUbuntu }}
 
+## Install CMAKE version 3.10.3 manually
+{{ layout.v.qrlCommands.cmakeInstall }}
+
+
 # Make sure setuptools is the latest
 pip3 install -U setuptools
 
@@ -77,6 +81,13 @@ Now install all the required dependencies:
 {{ layout.v.qrlCommands.qrlRequirementsUbuntu }}
 ```
 
+QRL requires `cmake v3.10.3` to be installed. Ubuntu repositories will install an incompatible version. Please install manually as shown below. If you already have `cmake` installed, please uninstall first.
+
+```bash
+# Install the required packages for QRL
+{{ layout.v.qrlCommands.cmakeInstall }}
+```
+
 ### Redhat/fedora
 
 Update:
@@ -92,6 +103,10 @@ Dependencies:
 # Install required packages
 {{ layout.v.qrlCommands.qrlRequirementsRedhat }}
 ```
+
+You will need to install `cmake v3.10.3` manually.
+
+[Please follow the guide from the cmake documentation](https://cmake.org/install/)
 
 
 ### MacOS
@@ -110,9 +125,12 @@ Having Issues? Please follow the instructions found at the brew main page: [http
 ```bash
 # Update brew
 brew update
-brew install cmake python3 swig boost hwloc
+brew install python3 swig boost hwloc
 ```
 
+You will need to install `cmake v3.10.3` manually.
+
+[Please follow the guide from the cmake documantation](https://cmake.org/install/)
 
 ### Windows 10
 

--- a/_docs/wallet/ledger-nano-s.md
+++ b/_docs/wallet/ledger-nano-s.md
@@ -129,7 +129,7 @@ Using the [Ledger Live](https://www.ledger.com/pages/ledger-live) application, f
 	- An installation window will appear, and your device will display **Processing...**
 	- The QRL App installation has completed on your Ledger Nano S
 
-## Initialising the QRL App
+## Initializing the QRL App
 
 Before you can use the QRL Ledger Nano S App, it must first be initialised. The initialisation process will generate an XMSS tree on your Ledger Nano S device, which is a unique aspect of the QRL Network's signature scheme. This process only has to be completed once on your Ledger Nano S device. Please allow up to 45 minutes for this process to complete for each tree. 
 

--- a/_docs/wallet/ledger-nano-s.md
+++ b/_docs/wallet/ledger-nano-s.md
@@ -138,7 +138,7 @@ To initialize your Ledger Nano S device for use with the QRL App, follow these i
 1. Make sure your Ledger Nano S device is **Connected** and **Unlocked**.
 2. Open the **QRL app** on your Ledger Nano S
 3. Your Ledger Nano S device will show **QRL (Tree 1) not ready**. 
-4. Scroll down and press both buttons on the **Init Device** menu option.
+4. Scroll down and press both buttons on the **Init Tree** menu option.
 5. Your Ledger Nano S device will show **QRL (Tree 1) keygen: 001/256**. This will slowly progress until all 256 keys have been generated.
 6. When this process has completed, your Ledger Nano S device will show **QRL (Tree 1) READY rem:256** - indicating your device has finished generating tree 1 OTS keys, and you have 256 OTS Keys remaining in this Tree.
 7. Scroll down in the menu and chose **Switch Tree** with both buttons. You will now see **QRL (Tree 2) Not Ready**

--- a/_docs/wallet/ledger-nano-s.md
+++ b/_docs/wallet/ledger-nano-s.md
@@ -131,9 +131,9 @@ Using the [Ledger Live](https://www.ledger.com/pages/ledger-live) application, f
 
 ## Initializing the QRL App
 
-Before you can use the QRL Ledger Nano S App, it must first be initialised. The initialisation process will generate an XMSS tree on your Ledger Nano S device, which is a unique aspect of the QRL Network's signature scheme. This process only has to be completed once on your Ledger Nano S device. Please allow up to 45 minutes for this process to complete for each tree. 
+Before you can use the QRL Ledger Nano S App, it must first be initialized. The initialization process will generate an XMSS tree on your Ledger Nano S device, which is a unique aspect of the QRL Network's signature scheme. This process only has to be completed once on your Ledger Nano S device. Please allow up to 45 minutes for this process to complete for each tree. 
 
-To initialise your Ledger Nano S device for use with the QRL App, follow these instructions:
+To initialize your Ledger Nano S device for use with the QRL App, follow these instructions:
 
 1. Make sure your Ledger Nano S device is **Connected** and **Unlocked**.
 2. Open the **QRL app** on your Ledger Nano S
@@ -146,7 +146,7 @@ To initialise your Ledger Nano S device for use with the QRL App, follow these i
 
 > Generating XMSS Tree 1 on the Ledger. This will take a while, have patience. ![Initializing Tree 1](/assets/wallet/web/ledger-nano-s/init-crop1.gif) 
 
-Your Ledger Nano S device has been initialised for the QRL app, and contains 2 addresses (XMSS Trees) ready to deposit funds to. 2 addresses contain 256 OTS keys each which can be used to sign transactions on the QRL network.
+Your Ledger Nano S device has been initialized for the QRL app, and contains 2 addresses (XMSS Trees) ready to deposit funds to. 2 addresses contain 256 OTS keys each which can be used to sign transactions on the QRL network.
 
 
 | QRL Tree | OTS Keys | Address |
@@ -257,7 +257,7 @@ You will see all of the transactions the address has as well as the balance of q
 
 ### Manually Set XMSS Index
 
-In the event you lose your Ledger Nano S device, or simply need to initialise or maintain the state of a second Ledger Nano S device, you can manually set the XMSS Index state on your Ledger Nano S device.
+In the event you lose your Ledger Nano S device, or simply need to initialize or maintain the state of a second Ledger Nano S device, you can manually set the XMSS Index state on your Ledger Nano S device.
 
 > **NOTE** If you are a Firefox user, ensure you have enabled **u2f** before proceeding. [Enabling U2F support in Mozilla Firefox](https://support.yubico.com/support/solutions/articles/15000017511-enabling-u2f-support-in-mozilla-firefox)
 {: .info}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -28,7 +28,8 @@ v:
        walletRemove: qrl wallet_rm          
        walletSecret: qrl wallet_secret      
        qrlRequirementsRedhat: dnf install swig cmake gcc gcc-c++ redhat-rpm-config python3-devel python-devel hwloc-devel boost-devel
-       qrlRequirementsUbuntu: sudo apt-get -y install swig3.0 python3-dev python3-pip build-essential cmake pkg-config libssl-dev libffi-dev libhwloc-dev libboost-dev
+       qrlRequirementsUbuntu: sudo apt-get -y install swig3.0 python3-dev python3-pip build-essential pkg-config libssl-dev libffi-dev libhwloc-dev libboost-dev
+       cmakeInstall: cd /opt && sudo wget https://github.com/Kitware/CMake/releases/download/v3.10.3/cmake-3.10.3.tar.gz && sudo tar zxvf cmake-3.10.3.tar.gz && cd cmake-3.10.3/ && sudo ./configure && sudo make -j2 && echo -e '## Adding cmake version 3.10.3\nPATH=$PATH:/opt/cmake-3.10.3/bin' >> ~/.bashrc && source ~/.bashrc
    qrlConf:
        qrlDir: ~/.qrl/
        confLocation: ~/.qrl/config.yml


### PR DESCRIPTION
* Updating installation instructions for Node installation. Newest version
of cmake is not compatable with the QRL node. Manual installation
instructions for cmake 3.10.3 added.

* Typo fix for Ledger Nano S - Initialising --> Initializing