### PR TITLE
Fix MiningOcean.org link

### DIFF
--- a/_includes/pool-selection.html
+++ b/_includes/pool-selection.html
@@ -27,7 +27,7 @@ QRL Address: <input type="text" id="address" placeholder="QRL Address">
             "testnet": false,
             "address":"https://qrl.miningocean.org/",
             "poolurl":"qrl.miningocean.org:5555",
-            "poolconfig":"https://qrl.miningocean.com/getting_started",
+            "poolconfig":"https://qrl.miningocean.org/getting_started",
             "blurb":"Comfortable & Reliable Quantum Resistant Ledger QRL Mining pool, run by first-class professionals. Adaptive DDOS Protection. Advanced support. World class service at a low 0.2% fee. Our qrl pool keeps your rig hashrate safe and secure! Join us to contribute to the decentralization of the network!"
         },
         {


### PR DESCRIPTION
changing from https://qrl.miningocean.com/ to https://qrl.miningocean.org/